### PR TITLE
Implemented `Base` file data type

### DIFF
--- a/storage/base.go
+++ b/storage/base.go
@@ -1,0 +1,16 @@
+package storage
+
+import "sync/atomic"
+
+type Base struct {
+  id int
+  page_count *atomic.Uint32
+}
+
+// can represent basefile id or file descriptor
+func (b Base) GetId() int { return b.id }
+func (b Base) GetPageCount() *atomic.Uint32 { return b.page_count }
+func (b Base) IncrementPageCount() { b.page_count.Add(1) }
+
+
+

--- a/storage/base.go
+++ b/storage/base.go
@@ -1,16 +1,36 @@
 package storage
 
-import "sync/atomic"
+import (
+	"log"
+	"os"
+	"sync/atomic"
+)
 
 type Base struct {
-  id int
-  page_count *atomic.Uint32
+  id int 
+  page_count uint32
 }
 
 // can represent basefile id or file descriptor
 func (b Base) GetId() int { return b.id }
-func (b Base) GetPageCount() *atomic.Uint32 { return b.page_count }
-func (b Base) IncrementPageCount() { b.page_count.Add(1) }
+func (b Base) GetPageCount() uint32 { return b.page_count }
+func (b Base) IncrementPageCount() { atomic.AddUint32(&b.page_count, 1) }
+
+func NewBaseFile(fileName string) *Base {
+  file, err := os.OpenFile(fileName, os.O_TRUNC|os.O_RDWR|os.O_CREATE, 0664)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  b := Base{ id: int(file.Fd()), page_count: 0 }
+  
+  err = file.Close()
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  return &b;
+}
 
 
 

--- a/storage/base.go
+++ b/storage/base.go
@@ -11,7 +11,7 @@ type Base struct {
   page_count uint32 // page_count is treated as an atomic integer
 }
 
-func (b Base) GetId() int { return b.fd }
+func (b Base) GetFd() int { return b.fd }
 func (b Base) GetPageCount() uint32 { return b.page_count }
 func (b Base) IncrementPageCount() { atomic.AddUint32(&b.page_count, 1) }
 

--- a/storage/base.go
+++ b/storage/base.go
@@ -7,12 +7,11 @@ import (
 )
 
 type Base struct {
-  id int 
-  page_count uint32
+  fd int // fd represents the file descriptor after opening a file  
+  page_count uint32 // page_count is treated as an atomic integer
 }
 
-// can represent basefile id or file descriptor
-func (b Base) GetId() int { return b.id }
+func (b Base) GetId() int { return b.fd }
 func (b Base) GetPageCount() uint32 { return b.page_count }
 func (b Base) IncrementPageCount() { atomic.AddUint32(&b.page_count, 1) }
 
@@ -22,7 +21,7 @@ func NewBaseFile(fileName string) *Base {
     log.Fatal(err)
   }
 
-  b := Base{ id: int(file.Fd()), page_count: 0 }
+  b := Base{ fd: int(file.Fd()), page_count: 0 }
   
   err = file.Close()
   if err != nil {

--- a/storage/base_test.go
+++ b/storage/base_test.go
@@ -16,6 +16,7 @@ func TestBaseFile(t *testing.T) {
       t.Logf("basefile is nil; not instantiated properly")
       t.Fail()
     }
+  
     if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
       t.Logf("expecting file path %s to be created", filePath)
       t.Fail()
@@ -27,12 +28,20 @@ func TestBaseFile(t *testing.T) {
     filePath := "../storage/fixtures/testfile_1.txt"
     basefile := NewBaseFile(filePath) 
 
+    // assert that the filePath already exists
+    if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
+      t.Logf("expecting file path %s to exist", filePath)
+      t.Fail()
+    }
+
     fd := basefile.GetFd();
     page_count := basefile.GetPageCount()
+    
     if(page_count != 0) {
       t.Logf("expecting page_count = 0, got %d", page_count)
       t.Fail()
     }
+    
     if(fd == -1) {
       t.Logf("expecting fd != -1, got %d", fd)
       t.Fail()

--- a/storage/base_test.go
+++ b/storage/base_test.go
@@ -1,0 +1,42 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestBaseFile(t *testing.T) {
+  t.Run(fmt.Sprintf("test: instantiate basefile with non-existent fixtures file"), func(t *testing.T) {
+    filePath := "../storage/fixtures/NON_EXISTENT.txt"
+    basefile := NewBaseFile(filePath) 
+    
+    if basefile == nil {
+      t.Logf("basefile is nil; not instantiated properly")
+      t.Fail()
+    }
+    if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
+      t.Logf("expecting file path %s to be created", filePath)
+      t.Fail()
+    }
+
+    os.Remove(filePath)
+  }) 
+  t.Run(fmt.Sprintf("test: instantiate basefile with existing fixtures file"), func(t *testing.T) {
+    filePath := "../storage/fixtures/testfile_1.txt"
+    basefile := NewBaseFile(filePath) 
+
+    fd := basefile.GetFd();
+    page_count := basefile.GetPageCount()
+    if(page_count != 0) {
+      t.Logf("expecting page_count = 0, got %d", page_count)
+      t.Fail()
+    }
+    if(fd == -1) {
+      t.Logf("expecting fd != -1, got %d", fd)
+      t.Fail()
+    }
+  }) 
+}
+

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -1,0 +1,3 @@
+module storage
+
+go 1.24.1


### PR DESCRIPTION
Details
-
- Added inline functions to get `fd` and `page_count` fields
- Added atomic increment for `page_count`
- Created constructor for `Base` by reading a file path (creates/truncates as options) and sets `fd` as the file descriptor of the read file
- Added test cases to test instantiation and file read/create