### PR TITLE
Implemented `Flush` for basefile 

### DIFF
--- a/essentials/essentials.go
+++ b/essentials/essentials.go
@@ -6,6 +6,9 @@ package essentials
   FID = File Identifier
   PN = Page Number
 */
+
+const PAGE_SIZE = 4096 // 4K pages
+
 type PageId struct {
   value uint64
 }

--- a/essentials/go.mod
+++ b/essentials/go.mod
@@ -1,3 +1,0 @@
-module essentials
-
-go 1.24.1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/AarhamH/tsmu
+
+go 1.24.1

--- a/storage/base.go
+++ b/storage/base.go
@@ -23,18 +23,19 @@ func NewBaseFile(fileName string) *Base {
 
   b := Base{ fd: int(file.Fd()), page_count: 0 }
   
-  err = file.Close()
-  if err != nil {
+  if err = file.Close(); err != nil {
     log.Fatal(err)
   }
 
   return &b;
 }
 
+// inlines for encapsulation
 func (b Base) GetFd() int { return b.fd }
 func (b Base) GetPageCount() uint32 { return b.page_count }
 func (b Base) IncrementPageCount() { atomic.AddUint32(&b.page_count, 1) }
 
+// Given a page id and a page buffer, write content of PAGE_SIZE to the file pointed by the page_id
 func (b Base) Flush (pid essentials.PageId, page []byte) error {
   // fail on invalid page id and nullptr
   if(page == nil) {
@@ -57,7 +58,7 @@ func (b Base) Flush (pid essentials.PageId, page []byte) error {
   }
     
   // final check to verify all data has been written to storage
-  if err := syscall.Fsync(b.fd); err != nil {
+  if err := syscall.Fsync(int(pid.GetFileId())); err != nil {
     return fmt.Errorf("data sync failed: %w", err)
   }
 

--- a/storage/base.go
+++ b/storage/base.go
@@ -11,10 +11,6 @@ type Base struct {
   page_count uint32 // page_count is treated as an atomic integer
 }
 
-func (b Base) GetFd() int { return b.fd }
-func (b Base) GetPageCount() uint32 { return b.page_count }
-func (b Base) IncrementPageCount() { atomic.AddUint32(&b.page_count, 1) }
-
 func NewBaseFile(fileName string) *Base {
   file, err := os.OpenFile(fileName, os.O_TRUNC|os.O_RDWR|os.O_CREATE, 0664)
   if err != nil {
@@ -31,5 +27,6 @@ func NewBaseFile(fileName string) *Base {
   return &b;
 }
 
-
-
+func (b Base) GetFd() int { return b.fd }
+func (b Base) GetPageCount() uint32 { return b.page_count }
+func (b Base) IncrementPageCount() { atomic.AddUint32(&b.page_count, 1) }

--- a/storage/base.go
+++ b/storage/base.go
@@ -1,9 +1,13 @@
 package storage
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"sync/atomic"
+	"syscall"
+
+	essentials "github.com/AarhamH/tsmu/essentials"
 )
 
 type Base struct {
@@ -30,3 +34,32 @@ func NewBaseFile(fileName string) *Base {
 func (b Base) GetFd() int { return b.fd }
 func (b Base) GetPageCount() uint32 { return b.page_count }
 func (b Base) IncrementPageCount() { atomic.AddUint32(&b.page_count, 1) }
+
+func (b Base) Flush (pid essentials.PageId, page []byte) error {
+  // fail on invalid page id and nullptr
+  if(page == nil) {
+    return fmt.Errorf("page is nil")
+  }
+
+  if(!pid.IsPageIdValid()) {
+    return fmt.Errorf("page id is invalid")
+  } 
+
+  var fileInfo syscall.Stat_t
+  if err := syscall.Fstat(b.fd, &fileInfo); err != nil {
+    return fmt.Errorf("failed to read basefile: %w", err)
+  }
+ 
+  // write PAGE_SIZE bytes into page buffer
+  writtenBytes, err := syscall.Pwrite(int(pid.GetFileId()), page, int64(pid.GetPageNumber() * essentials.PAGE_SIZE))
+  if err != nil || writtenBytes != essentials.PAGE_SIZE {
+    return fmt.Errorf("write failed or incomplete: %w", err)
+  }
+    
+  // final check to verify all data has been written to storage
+  if err := syscall.Fsync(b.fd); err != nil {
+    return fmt.Errorf("data sync failed: %w", err)
+  }
+
+  return nil;
+}

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -1,3 +1,0 @@
-module storage
-
-go 1.24.1

--- a/tests/base_test.go
+++ b/tests/base_test.go
@@ -6,28 +6,33 @@ import (
 	"os"
 	"testing"
   basefile "github.com/AarhamH/tsmu/storage"
+  essentials "github.com/AarhamH/tsmu/essentials"
 )
+
+const newlyCreatedFilePath = "../tests/fixtures/new_file.txt"
+const filePath = "../tests/fixtures/testfile_1.txt"
 
 func TestBaseFile(t *testing.T) {
   t.Run(fmt.Sprintf("test: instantiate basefile with non-existent fixtures file"), func(t *testing.T) {
-    filePath := "../storage/fixtures/NON_EXISTENT.txt"
-    basefile := basefile.NewBaseFile(filePath) 
+    // Initialize basefile
+    basefile, file := basefile.NewBaseFile(newlyCreatedFilePath) 
     
     if basefile == nil {
       t.Logf("basefile is nil; not instantiated properly")
       t.Fail()
     }
   
-    if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
+    if _, err := os.Stat(newlyCreatedFilePath); errors.Is(err, os.ErrNotExist) {
       t.Logf("expecting file path %s to be created", filePath)
       t.Fail()
     }
 
-    os.Remove(filePath)
-  }) 
+    basefile.CloseFile(*file)
+    os.Remove(newlyCreatedFilePath)
+  })
+
   t.Run(fmt.Sprintf("test: instantiate basefile with existing fixtures file"), func(t *testing.T) {
-    filePath := "../storage/fixtures/testfile_1.txt"
-    basefile := basefile.NewBaseFile(filePath) 
+    basefile, file := basefile.NewBaseFile(filePath) 
 
     // assert that the filePath already exists
     if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
@@ -47,6 +52,38 @@ func TestBaseFile(t *testing.T) {
       t.Logf("expecting fd != -1, got %d", fd)
       t.Fail()
     }
+    basefile.CloseFile(*file)
+  }) 
+
+  t.Run(fmt.Sprintf("test: flush page to valid file"), func(t *testing.T) {
+    basefile,file := basefile.NewBaseFile(newlyCreatedFilePath)
+
+    // assert that the filePath has been created
+    if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
+      t.Logf("expecting file path %s to be created", newlyCreatedFilePath)
+      t.Fail()
+    }
+    
+    fd := basefile.GetFd();
+    
+    pageId := essentials.NewPageId(fd, 0)
+    buff := []byte("This is sample text")
+    if err := basefile.Flush(*pageId, buff); err != nil {
+      t.Errorf("error occured when flushing page %e", err)
+      t.Fail()
+    }
+    content, err := os.ReadFile(newlyCreatedFilePath)
+    if err != nil {
+      t.Errorf("error occured when reading file: %e", err)
+      t.Fail()
+    }
+
+    if string(buff) != string(content) {
+      t.Errorf("expecting the content: %s, got: %s", string(buff), string(content))
+      t.Fail()
+    }
+    basefile.CloseFile(*file)
+    os.Remove(newlyCreatedFilePath)
   }) 
 }
 

--- a/tests/base_test.go
+++ b/tests/base_test.go
@@ -9,12 +9,13 @@ import (
   essentials "github.com/AarhamH/tsmu/essentials"
 )
 
-const newlyCreatedFilePath = "../tests/fixtures/new_file.txt"
 const filePath = "../tests/fixtures/testfile_1.txt"
 
 func TestBaseFile(t *testing.T) {
   t.Run(fmt.Sprintf("test: instantiate basefile with non-existent fixtures file"), func(t *testing.T) {
     // Initialize basefile
+   
+    newlyCreatedFilePath := "../tests/fixtures/new_file.txt"
     basefile, file := basefile.NewBaseFile(newlyCreatedFilePath) 
     
     if basefile == nil {
@@ -56,11 +57,11 @@ func TestBaseFile(t *testing.T) {
   }) 
 
   t.Run(fmt.Sprintf("test: flush page to valid file"), func(t *testing.T) {
-    basefile,file := basefile.NewBaseFile(newlyCreatedFilePath)
+    basefile,file := basefile.NewBaseFile(filePath)
 
     // assert that the filePath has been created
     if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
-      t.Logf("expecting file path %s to be created", newlyCreatedFilePath)
+      t.Logf("expecting file path %s to be created", filePath)
       t.Fail()
     }
     
@@ -72,7 +73,7 @@ func TestBaseFile(t *testing.T) {
       t.Errorf("error occured when flushing page %e", err)
       t.Fail()
     }
-    content, err := os.ReadFile(newlyCreatedFilePath)
+    content, err := os.ReadFile(filePath)
     if err != nil {
       t.Errorf("error occured when reading file: %e", err)
       t.Fail()
@@ -83,7 +84,20 @@ func TestBaseFile(t *testing.T) {
       t.Fail()
     }
     basefile.CloseFile(*file)
-    os.Remove(newlyCreatedFilePath)
+  })
+
+  t.Run(fmt.Sprintf("test: flush page given invalid buffer"), func(t *testing.T) {
+    basefile,file := basefile.NewBaseFile(filePath)
+    
+    fd := basefile.GetFd();
+    
+    pageId := essentials.NewPageId(fd, 0)
+    if err := basefile.Flush(*pageId, nil); err == nil {
+      t.Errorf("expecting error for nil page buffer")
+      t.Fail()
+    }
+    basefile.CloseFile(*file)
+    os.Remove(filePath)
   }) 
 }
 

--- a/tests/base_test.go
+++ b/tests/base_test.go
@@ -13,9 +13,9 @@ const filePath = "../tests/fixtures/testfile_1.txt"
 
 func TestBaseFile(t *testing.T) {
   t.Run(fmt.Sprintf("test: instantiate basefile with non-existent fixtures file"), func(t *testing.T) {
-    // Initialize basefile
-   
     newlyCreatedFilePath := "../tests/fixtures/new_file.txt"
+    
+    // Initialize basefile
     basefile, file := basefile.NewBaseFile(newlyCreatedFilePath) 
     
     if basefile == nil {
@@ -28,6 +28,7 @@ func TestBaseFile(t *testing.T) {
       t.Fail()
     }
 
+    // Close
     basefile.CloseFile(*file)
     os.Remove(newlyCreatedFilePath)
   })
@@ -53,17 +54,14 @@ func TestBaseFile(t *testing.T) {
       t.Logf("expecting fd != -1, got %d", fd)
       t.Fail()
     }
+
+    // Close
     basefile.CloseFile(*file)
   }) 
 
   t.Run(fmt.Sprintf("test: flush page to valid file"), func(t *testing.T) {
+    // Initialize basefile
     basefile,file := basefile.NewBaseFile(filePath)
-
-    // assert that the filePath has been created
-    if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
-      t.Logf("expecting file path %s to be created", filePath)
-      t.Fail()
-    }
     
     fd := basefile.GetFd();
     
@@ -73,6 +71,8 @@ func TestBaseFile(t *testing.T) {
       t.Errorf("error occured when flushing page %e", err)
       t.Fail()
     }
+    
+    // read contents of file and compare with buffer
     content, err := os.ReadFile(filePath)
     if err != nil {
       t.Errorf("error occured when reading file: %e", err)
@@ -83,10 +83,13 @@ func TestBaseFile(t *testing.T) {
       t.Errorf("expecting the content: %s, got: %s", string(buff), string(content))
       t.Fail()
     }
+
+    // Close
     basefile.CloseFile(*file)
   })
 
   t.Run(fmt.Sprintf("test: flush page given invalid buffer"), func(t *testing.T) {
+    // Initialize basefile
     basefile,file := basefile.NewBaseFile(filePath)
     
     fd := basefile.GetFd();
@@ -96,8 +99,9 @@ func TestBaseFile(t *testing.T) {
       t.Errorf("expecting error for nil page buffer")
       t.Fail()
     }
+
+    // Close
     basefile.CloseFile(*file)
-    os.Remove(filePath)
   }) 
 }
 

--- a/tests/base_test.go
+++ b/tests/base_test.go
@@ -1,16 +1,17 @@
-package storage
+package tests
 
 import (
 	"errors"
 	"fmt"
 	"os"
 	"testing"
+  basefile "github.com/AarhamH/tsmu/storage"
 )
 
 func TestBaseFile(t *testing.T) {
   t.Run(fmt.Sprintf("test: instantiate basefile with non-existent fixtures file"), func(t *testing.T) {
     filePath := "../storage/fixtures/NON_EXISTENT.txt"
-    basefile := NewBaseFile(filePath) 
+    basefile := basefile.NewBaseFile(filePath) 
     
     if basefile == nil {
       t.Logf("basefile is nil; not instantiated properly")
@@ -26,7 +27,7 @@ func TestBaseFile(t *testing.T) {
   }) 
   t.Run(fmt.Sprintf("test: instantiate basefile with existing fixtures file"), func(t *testing.T) {
     filePath := "../storage/fixtures/testfile_1.txt"
-    basefile := NewBaseFile(filePath) 
+    basefile := basefile.NewBaseFile(filePath) 
 
     // assert that the filePath already exists
     if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {

--- a/tests/essentials_test.go
+++ b/tests/essentials_test.go
@@ -1,9 +1,10 @@
-package essentials
+package tests
 
 import (
 	"fmt"
 	"testing"
   "math/rand/v2"
+  essentials "github.com/AarhamH/tsmu/essentials"
 )
 
 func TestPageId(t *testing.T) {
@@ -11,7 +12,7 @@ func TestPageId(t *testing.T) {
   pageNum := rand.IntN(100)
 
   t.Run(fmt.Sprintf("test: pageId generated with random fileId and pageNum"), func(t *testing.T) {
-    pid := NewPageId(fileId, uint64(pageNum))
+    pid := essentials.NewPageId(fileId, uint64(pageNum))
     isValid := pid.IsPageIdValid() 
     if !isValid {
       t.Logf("Expected IsPageIdValid = true, got %t", isValid)
@@ -20,7 +21,7 @@ func TestPageId(t *testing.T) {
   })
 
   t.Run(fmt.Sprintf("test: pageId calculates accurate pageNum"), func(t *testing.T) {
-    pid := NewPageId(fileId, uint64(pageNum))
+    pid := essentials.NewPageId(fileId, uint64(pageNum))
     isValid := pid.IsPageIdValid() 
     if !isValid {
       t.Logf("Expected IsPageIdValid = true, got %t", isValid)
@@ -34,7 +35,7 @@ func TestPageId(t *testing.T) {
   })
 
   t.Run(fmt.Sprintf("test: pageId calculates accurate fileId"), func(t *testing.T) {
-    pid := NewPageId(fileId, uint64(pageNum))
+    pid := essentials.NewPageId(fileId, uint64(pageNum))
     isValid := pid.IsPageIdValid() 
     if !isValid {
       t.Logf("Expected IsPageIdValid = true, got %t", isValid)
@@ -53,13 +54,13 @@ func TestRecordId(t *testing.T) {
   pageNum := rand.IntN(100)
   slotId := rand.IntN(100)
   t.Run(fmt.Sprintf("test: recordId is valid"), func(t *testing.T) {
-    pid := NewPageId(fileId, uint64(pageNum))
+    pid := essentials.NewPageId(fileId, uint64(pageNum))
     isValid := pid.IsPageIdValid() 
     if !isValid {
       t.Logf("Expected IsPageIdValid = true, got %t", isValid)
       t.Fail()
     }
-    rid := NewRecordId(pid, uint64(slotId))
+    rid := essentials.NewRecordId(pid, uint64(slotId))
     isValid = rid.IsRecordIdValid()
     if !isValid {
       t.Logf("Expected IsRecordIdValid =, got %t", isValid)
@@ -68,13 +69,13 @@ func TestRecordId(t *testing.T) {
   })
 
   t.Run(fmt.Sprintf("test: recordId calculates accurate slotId"), func(t *testing.T) {
-    pid := NewPageId(fileId, uint64(pageNum))
+    pid := essentials.NewPageId(fileId, uint64(pageNum))
     isValid := pid.IsPageIdValid() 
     if !isValid {
       t.Logf("Expected IsPageIdValid = true, got %t", isValid)
       t.Fail()
     }
-    rid := NewRecordId(pid, uint64(slotId))
+    rid := essentials.NewRecordId(pid, uint64(slotId))
     isValid = rid.IsRecordIdValid()
     if !isValid {
       t.Logf("Expected IsRecordIdValid =, got %t", isValid)

--- a/tests/fixtures/new_file.txt
+++ b/tests/fixtures/new_file.txt
@@ -1,1 +1,0 @@
-This is sample text

--- a/tests/fixtures/new_file.txt
+++ b/tests/fixtures/new_file.txt
@@ -1,0 +1,1 @@
+This is sample text


### PR DESCRIPTION
Details
-
- implemented `Flush` which writes to a file provided by a page buffer, pointed to by a `page_id`
- added test cases for `Flush`; testing if content is written to file reliably, and failure given invalid page buffer